### PR TITLE
Implement regexes for matching several issue trackers

### DIFF
--- a/src/docstats/utils.py
+++ b/src/docstats/utils.py
@@ -56,6 +56,15 @@ _BUGTRACKER_REGEXES = (
                r'resolve[sd]?)'
                r'(?:\s+(?:for))?'
                r'\s?#(?P<id>\d{1,9})', re.IGNORECASE),
+
+    # external GitHub repositories
+    re.compile(r'(?P<github>[fF]ix(?:es|ed)?|' + \
+               r'[cC]lose[sd]?|' + \
+               r'[rR]esolve[sd]?)' + \
+               r'\s?' + \
+               r'%s#(?P<id>\d{1,9})' % _DOMAIN_REPO_REGEX
+    ),
+
     # see https://en.opensuse.org/openSUSE:Creating_a_changes_file_(RPM)#Bug_fix.2C_feature_implementation
     # https://en.opensuse.org/openSUSE:Packaging_Patches_guidelines#Current_set_of_abbreviations
     re.compile(r'(?P<bugtracker>bsc|bnc|boo|[fF]ate|FATE)'
@@ -151,6 +160,10 @@ def findbugid(text):
         # "normalize" the text part of the match
         return [(text.lower(), number) for text, number in m]
 
+    def _ext_github(m):
+        # "normalize" the text, domain, and repo part of the match
+        return [(text.lower(), middle[0].lower(), middle[1].lower(), number) for text, *middle, number in m]
+
     def _bugtracker(m):
         # we reuse the function from _github which just make the text
         # lowercase
@@ -161,7 +174,7 @@ def findbugid(text):
         return m
 
     # Order must match the regexes in _BUGTRACKER_REGEXES
-    functions = [_github, _bugtracker, _cve]
+    functions = [_github, _ext_github, _bugtracker, _cve]
 
     result = [ ]
     # Iterate through all possible regexes and deliver a tuple of
@@ -180,6 +193,7 @@ def findcommits(text):
 
     :param text: the text with possible commit hashes
     :return: a list of all found commit hashes
+    :rtype: list
     """
     _COMMIT_HASH_REGEX = re.compile(r'(?P<commit>[cC]ommit)?'
                                     r'\s?[#]?'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -110,7 +110,23 @@ def test_findbugid_github(text, expected):
     assert findbugid(text) == expected
 
 
+
 @pytest.mark.parametrize('text,expected', [
+    #
+    ('the quick brown fox', []),
+    #
+    ('Closes tux/example_repo#76', [('closes', 'tux', 'example_repo', '76')]),
+    #
+    ('Closes Tux/Example_Repo#76', [('closes', 'tux', 'example_repo', '76')]),
+])
+def test_findbugid_extern_github(text, expected):
+    # Just for GitHub issues
+    assert findbugid(text) == expected
+
+
+@pytest.mark.parametrize('text,expected', [
+    #
+    ('the quick brown fox', []),
     # For different bugtracker issues
     ('bsc#12345', [('bsc', '12345')]),
     #
@@ -131,6 +147,8 @@ def test_findbugid_bugtracker(text, expected):
 
 @pytest.mark.parametrize('text,expected', [
     #
+    ('the quick brown fox', []),
+    #
     ('CVE-2017-1234', [('CVE', '2017-1234')]),
     #
 ])
@@ -140,6 +158,8 @@ def test_findbugid_cve(text, expected):
 
 
 @pytest.mark.parametrize('text,expected', [
+    #
+    ('the quick brown fox', []),
     #
     ('commit de9ddf8', [('commit', 'de9ddf8')]),
     #

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch
 
-from docstats.utils import git_urlparse, http_urlparse, gettmpdir, urlparse
+from docstats.utils import git_urlparse, http_urlparse, gettmpdir, urlparse, findbugid, findcommits
 
 
 @pytest.mark.parametrize('url,expected', [
@@ -70,3 +70,88 @@ def test_http_urlparse(url, expected):
 def test_tmpdir(path, expected):
     with patch.dict('os.environ', {'HOSTNAME': 'myhost', 'USER': 'tux', 'LANG': 'en'}):
         assert gettmpdir(path) == expected
+
+
+@pytest.mark.parametrize('text,expected', [
+    #
+    ('normal text',   []),
+    #
+    ('text with 123,', []),
+    #
+    (" fix #123 ", [('fix', '123')]),
+    #
+    (" fixes #123! ", [('fixes', '123')]),
+    #
+    (" Fixed #123: ", [('fixed', '123')]),
+    #
+    (" close #123 ", [('close', '123')]),
+    #
+    (" closes #123 ", [('closes', '123')]),
+    #
+    (" closed #123 ", [('closed', '123')]),
+    #
+    (" resolve #123 ", [('resolve', '123')]),
+    #
+    (" resolves #123 ", [('resolves', '123')]),
+    #
+    (" resolved #123 ", [('resolved', '123')]),
+    #
+    ('and this fixes #123!', [('fixes', '123')]),
+    #
+    ('had fixed #123!', [('fixed', '123')]),
+    # Multiple cases
+    (" close #123, closes #345 ", [('close', '123'), ('closes', '345')]),
+    # Special case "fix for #..."
+    (" fix for #123 ", [('fix', '123')]),
+
+])
+def test_findbugid_github(text, expected):
+    # Just for GitHub issues
+    assert findbugid(text) == expected
+
+
+@pytest.mark.parametrize('text,expected', [
+    # For different bugtracker issues
+    ('bsc#12345', [('bsc', '12345')]),
+    #
+    ('bnc#12345', [('bnc', '12345')]),
+    #
+    ('bnc #12345', [('bnc', '12345')]),
+    #
+    ('fix bnc#12345', [('bnc', '12345')]),
+    #
+    ('see bsc#123, bsc #345, and bsc#5678', [('bsc', '123'), ('bsc', '345'), ('bsc', '5678')]),
+    #
+    ('see Fate#123, FATE#345, and fate#5678', [('fate', '123'), ('fate', '345'), ('fate', '5678')]),
+])
+def test_findbugid_bugtracker(text, expected):
+
+    assert findbugid(text) == expected
+
+
+@pytest.mark.parametrize('text,expected', [
+    #
+    ('CVE-2017-1234', [('CVE', '2017-1234')]),
+    #
+])
+def test_findbugid_cve(text, expected):
+    # Common Vulnerabilities and Exposures(CVE)
+    assert findbugid(text) == expected
+
+
+@pytest.mark.parametrize('text,expected', [
+    #
+    ('commit de9ddf8', [('commit', 'de9ddf8')]),
+    #
+    ('commit #de9ddf8', [('commit', 'de9ddf8')]),
+    #
+    ('#de9ddf8', [('commit', 'de9ddf8')]),
+    #
+    ('de9ddf8, abede', [('commit', 'de9ddf8'), ('commit', 'abede')]),
+    #
+    ('abcdf, x123, 345', [('commit', 'abcdf')]),
+    # Hmn... should we remove this as a possible commit?
+    ('the deadfeed, ', [('commit', 'deadfeed')]),
+])
+def test_findcommits(text, expected):
+    assert findcommits(text) == expected


### PR DESCRIPTION
Changes in this pr:

* Rework `urlparse`, `http_urlparse`, `git_urlparse`
  * Splits regexes into different string which can be combined later
  * Cuts off the ".git" part if available to simplify regex
  * Make variable naming more consistent (..._REGEX for a single regular expression)

* Implement findbugid and findcommits functions
  Find Bugzilla, Fate, GitHub issues etc. in text (for example, commit messages)

*  `findbugid`: support external GitHub repositories
   Can now detect text like `closes example_user/example_repo#42`